### PR TITLE
Support PyQt6

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -45,3 +45,4 @@ Category of the plugin: Raster, Vector, Database or Web
 # If the plugin can run on QGIS Server.
 server=False
 
+supportsQt6=True

--- a/whitebox_workflows_for_qgis_algorithm.py
+++ b/whitebox_workflows_for_qgis_algorithm.py
@@ -340,11 +340,11 @@ class WhiteboxWorkflowsAlgorithm(QgsProcessingAlgorithm):
         res = proc.run(feedback)
         if feedback.isCanceled() and res != 0:
             feedback.pushInfo('Process was canceled and did not complete.')
-        elif not feedback.isCanceled() and proc.exitStatus() == QProcess.CrashExit:
+        elif not feedback.isCanceled() and proc.exitStatus() == QProcess.ExitStatus.CrashExit:
             raise QgsProcessingException('Process was unexpectedly terminated.')
         elif res == 0:
             feedback.pushInfo('Process completed successfully.')
-        elif proc.processError() == QProcess.FailedToStart:
+        elif proc.processError() == QProcess.ProcessError.FailedToStart:
             raise QgsProcessingException('Process "{}" failed to start. Either "{}" is missing, or you may have insufficient permissions to run the program.'.format(command, command))
         else:
             feedback.reportError('Process returned error code {}'.format(res))


### PR DESCRIPTION
- Use full names to reference enums, for maximum compatibility. See https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6 for reference.
- Declare support for PyQt6 in metadata file. 
- Compatibility for QGIS 4.x is not declared, because there may be other breaking changes in 4.x that we don't know about yet.

Fixes #7 